### PR TITLE
Wrap data to `handleSubmit` in a `formData` object

### DIFF
--- a/src/containers/ResourceForm/ResourceForm.jsx
+++ b/src/containers/ResourceForm/ResourceForm.jsx
@@ -194,8 +194,10 @@ class ResourceForm extends Component {
                   open: true,
                   onProceed: () => {
                     this.handleSubmit({
-                      '@id': formData['@id'],
-                      'dcat:accessURL': 'remove'
+                      formData: {
+                        '@id': formData['@id'],
+                        'dcat:accessURL': 'remove'
+                      }
                     });
                   }
                 })}


### PR DESCRIPTION
Fixes DP-5803

The `handleSubmit` function of the `ResourceForm` expects an object
containing a `formData` property which holds the data. From the modal
dialog `onProceed` event, the `handleSubmit` was called directly with the
required data, instead of passing along an event. It was however not
wrapped in a `formData` object.