### PR TITLE
DP-5897: reload the datasets list after adding, editing or removing a…

### DIFF
--- a/src/actions/dataset/dataset.js
+++ b/src/actions/dataset/dataset.js
@@ -2,6 +2,7 @@ import { getAuthHeaders } from '../../services/auth/auth';
 import serverError from '../../services/server-error/server-error';
 import redirectToPortal from '../../services/redirect-to-portal/redirect-to-portal';
 import { fetchSchema } from '../schema/schema';
+import { fetchDatasets } from '../datasets/datasets';
 import api from '../../services/api/api';
 
 export const FETCH_DATASET_SUCCESS = 'FETCH_DATASET_SUCCESS';
@@ -59,6 +60,9 @@ export function createDataset(dataset) {
       .then(response =>
         dispatch(response.ok ? createDatasetSuccess(dataset) : serverError(response)))
       .then(() => {
+        dispatch(fetchDatasets());
+      })
+      .then(() => {
         redirectToPortal();
       })
       .catch((error) => { throw error; });
@@ -112,6 +116,9 @@ export function updateDataset(dataset) {
       .then(response =>
         dispatch(response.ok ? updateDatasetSuccess() : serverError(response)))
       .then(() => {
+        dispatch(fetchDatasets());
+      })
+      .then(() => {
         redirectToPortal();
       })
       .catch((error) => { throw error; });
@@ -137,7 +144,10 @@ export function removeDataset(dataset) {
       .then(response =>
         dispatch(response.ok ? removeDatasetSuccess() : serverError(response)))
       .then(() => {
-        redirectToPortal('list');
+        dispatch(fetchDatasets());
+      })
+      .then(() => {
+        redirectToPortal();
       })
       .catch((error) => { throw error; });
   };

--- a/src/actions/dataset/dataset.js
+++ b/src/actions/dataset/dataset.js
@@ -59,12 +59,8 @@ export function createDataset(dataset) {
     })
       .then(response =>
         dispatch(response.ok ? createDatasetSuccess(dataset) : serverError(response)))
-      .then(() => {
-        dispatch(fetchDatasets());
-      })
-      .then(() => {
-        redirectToPortal();
-      })
+      .then(() => dispatch(fetchDatasets()))
+      .then(() => redirectToPortal())
       .catch((error) => { throw error; });
   };
 }
@@ -115,12 +111,8 @@ export function updateDataset(dataset) {
     })
       .then(response =>
         dispatch(response.ok ? updateDatasetSuccess() : serverError(response)))
-      .then(() => {
-        dispatch(fetchDatasets());
-      })
-      .then(() => {
-        redirectToPortal();
-      })
+      .then(() => dispatch(fetchDatasets()))
+      .then(() => redirectToPortal())
       .catch((error) => { throw error; });
   };
 }
@@ -143,12 +135,8 @@ export function removeDataset(dataset) {
     })
       .then(response =>
         dispatch(response.ok ? removeDatasetSuccess() : serverError(response)))
-      .then(() => {
-        dispatch(fetchDatasets());
-      })
-      .then(() => {
-        redirectToPortal();
-      })
+      .then(() => dispatch(fetchDatasets()))
+      .then(() => redirectToPortal())
       .catch((error) => { throw error; });
   };
 }


### PR DESCRIPTION
Reload the datasets list after adding, editing or removing a dataset when using dcat_admin as a standalone product (not through Atlas)